### PR TITLE
Refactor translation interface

### DIFF
--- a/components/audio-controls.tsx
+++ b/components/audio-controls.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Mic, Square } from 'lucide-react';
+import { Button } from './ui/button';
+import { cn } from '@/lib/utils';
+import { forwardRef } from 'react';
+
+interface AudioControlsProps {
+  isRecording: boolean;
+  isLoading: boolean;
+  onToggle: () => void;
+}
+
+export const AudioControls = forwardRef<HTMLAudioElement, AudioControlsProps>(
+  function AudioControls({ isRecording, isLoading, onToggle }, ref) {
+    return (
+      <>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={onToggle}
+          className={cn(
+            'shrink-0 transition-colors duration-200',
+            isRecording && 'bg-red-500 border-red-500 hover:bg-red-600 hover:border-red-600',
+          )}
+          disabled={isLoading}
+        >
+          {isRecording ? (
+            <Square className="h-4 w-4 fill-white text-white" />
+          ) : (
+            <Mic className="h-4 w-4" />
+          )}
+        </Button>
+        <audio ref={ref} className="hidden" />
+      </>
+    );
+  },
+);

--- a/components/input-controls.tsx
+++ b/components/input-controls.tsx
@@ -2,25 +2,21 @@
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Mic, Send } from 'lucide-react';
+import { Send } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface InputControlsProps {
   inputText: string;
   isLoading: boolean;
-  isRecording: boolean;
   onInputChange: (value: string) => void;
   onSend: () => void;
-  onRecord: () => void;
 }
 
 export function InputControls({
   inputText,
   isLoading,
-  isRecording,
   onInputChange,
   onSend,
-  onRecord
 }: InputControlsProps) {
   return (
     <div className="flex gap-2 w-full">
@@ -33,18 +29,6 @@ export function InputControls({
         disabled={isLoading}
       />
       
-      <Button
-        variant="outline"
-        size="icon"
-        onClick={onRecord}
-        className={cn(
-          "shrink-0 transition-colors duration-200",
-          isRecording && "bg-red-500 text-white border-red-500 hover:bg-red-600 hover:text-white"
-        )}
-        disabled={isLoading}
-      >
-        <Mic className={cn("h-4 w-4", isRecording && "animate-pulse")} />
-      </Button>
       
       <Button 
         onClick={onSend} 

--- a/components/message-list.tsx
+++ b/components/message-list.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useMemo, useRef, useEffect, useState } from 'react';
+import { Button } from './ui/button';
+import { ChevronUp } from 'lucide-react';
+import { MessageBubble } from './message-bubble';
+import { cn } from '@/lib/utils';
+import type { TranslationMessage } from '@/lib/types';
+
+interface MessageListProps {
+  messages: TranslationMessage[];
+  isPlaying: number | null;
+  onPlay: (text: string, index: number, targetLang: string) => void;
+  onDelete: (id: string) => void;
+}
+
+export function MessageList({ messages, isPlaying, onPlay, onDelete }: MessageListProps) {
+  const [showPrevious, setShowPrevious] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const reversedMessages = useMemo(() => [...messages].reverse(), [messages]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages.length]);
+
+  return (
+    <div className="relative flex-1 overflow-y-auto">
+      <div className="mx-auto w-full max-w-5xl px-4 pt-20 flex flex-col items-center">
+        {reversedMessages.length > 1 && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="mb-2 mt-1 h-8 w-8 rounded-full border border-gray-100 shadow-sm hover:shadow-md transition-all duration-200 bg-white/95 backdrop-blur-sm"
+            onClick={() => setShowPrevious(!showPrevious)}
+          >
+            <ChevronUp
+              className={cn(
+                'h-4 w-4 text-gray-400 transition-transform duration-200',
+                showPrevious && 'rotate-180',
+              )}
+            />
+          </Button>
+        )}
+
+        <div className="w-full">
+          {showPrevious &&
+            reversedMessages.slice(1).map((message, index) => (
+              <div
+                key={message.id}
+                className={cn(
+                  'w-full transition-all duration-300',
+                  'opacity-0 translate-y-4',
+                  showPrevious && 'opacity-100 translate-y-0',
+                )}
+              >
+                <MessageBubble
+                  text={message.text}
+                  translation={message.translation}
+                  fromLang={message.fromLang}
+                  toLang={message.toLang}
+                  cultural={message.cultural}
+                  isPlaying={isPlaying === index + 1}
+                  onPlay={() => onPlay(message.translation, index + 1, message.toLang)}
+                  onDelete={() => onDelete(message.id)}
+                />
+              </div>
+            ))}
+        </div>
+      </div>
+
+      <div className="flex-1 flex items-center justify-center px-4 pb-8 mt-4">
+        <div ref={messagesEndRef} />
+        {reversedMessages[0] && (
+          <div className="w-full">
+            <MessageBubble
+              text={reversedMessages[0].text}
+              translation={reversedMessages[0].translation}
+              fromLang={reversedMessages[0].fromLang}
+              toLang={reversedMessages[0].toLang}
+              cultural={reversedMessages[0].cultural}
+              isPlaying={isPlaying === 0}
+              onPlay={() => onPlay(reversedMessages[0].translation, 0, reversedMessages[0].toLang)}
+              onDelete={() => onDelete(reversedMessages[0].id)}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/message-utils.ts
+++ b/lib/message-utils.ts
@@ -1,0 +1,25 @@
+import type { TranslationMessage } from './types';
+
+export function createMessage({
+  text,
+  translation,
+  fromLang,
+  toLang,
+  cultural,
+}: {
+  text: string;
+  translation: string;
+  fromLang: string;
+  toLang: string;
+  cultural?: string;
+}): TranslationMessage {
+  return {
+    id: Math.random().toString(36).substr(2, 9),
+    text,
+    translation: translation.trim(),
+    cultural: cultural?.trim() || undefined,
+    fromLang,
+    toLang,
+    timestamp: Date.now(),
+  };
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,0 +1,40 @@
+export const MAX_STORED_MESSAGES = 50;
+
+import type { TranslationMessage } from './types';
+import { STORAGE_KEYS } from './constants';
+import { isValidLanguageCode, LanguageCode } from './languages';
+
+export function getStoredLanguage(
+  key: string,
+  fallback: LanguageCode,
+): LanguageCode {
+  if (typeof window === 'undefined') return fallback;
+  const stored = localStorage.getItem(key);
+  return stored && isValidLanguageCode(stored) ? stored : fallback;
+}
+
+export function getStoredAutoSwitch(): boolean {
+  if (typeof window === 'undefined') return false;
+  return localStorage.getItem(STORAGE_KEYS.AUTO_SWITCH) === 'true';
+}
+
+export function getStoredMessages(): TranslationMessage[] {
+  if (typeof window === 'undefined') return [];
+  const stored = localStorage.getItem(STORAGE_KEYS.MESSAGES);
+  if (!stored) return [];
+  try {
+    const messages: TranslationMessage[] = JSON.parse(stored);
+    return messages.map((msg) => ({
+      ...msg,
+      id: msg.id || Math.random().toString(36).substr(2, 9),
+    }));
+  } catch {
+    return [];
+  }
+}
+
+export function storeMessages(messages: TranslationMessage[]): void {
+  if (typeof window === 'undefined') return;
+  const limited = messages.slice(-MAX_STORED_MESSAGES);
+  localStorage.setItem(STORAGE_KEYS.MESSAGES, JSON.stringify(limited));
+}


### PR DESCRIPTION
## Summary
- extract storage helpers and message creator
- add audio and message list components
- simplify `InputControls`
- refactor `translation-interface` to use the new pieces

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423c98ea64832ca995ac9041a17e0a